### PR TITLE
Fix CLI docstring typo

### DIFF
--- a/src/whispr/cli.py
+++ b/src/whispr/cli.py
@@ -30,7 +30,7 @@ def cli():
     """Whispr is a CLI tool to safely inject vault secrets into an application.
     Run `whispr init <vault>` to create a configuration.
 
-    Availble values for <vault>: ["aws", "azure", "gcp"]
+    Available values for <vault>: ["aws", "azure", "gcp"]
     """
     pass
 


### PR DESCRIPTION
## Summary
- correct "Availble" to "Available" in `cli` docstring

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements_test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ab20400c8332adba4f9d99b42073